### PR TITLE
inject monaco instance when init instead of cdn

### DIFF
--- a/src/spec.js
+++ b/src/spec.js
@@ -32,9 +32,15 @@ describe('.config', () => {
       return () => loader.config(config);
     }
 
-    expect(callConfigWithNonObjectFirstArgument('string')).toThrow(errorMessages.configType);
-    expect(callConfigWithNonObjectFirstArgument([1, 2, 3])).toThrow(errorMessages.configType);
-    expect(callConfigWithNonObjectFirstArgument(x => x + 1)).toThrow(errorMessages.configType);
+    expect(callConfigWithNonObjectFirstArgument('string')).toThrow(
+      errorMessages.configType
+    );
+    expect(callConfigWithNonObjectFirstArgument([1, 2, 3])).toThrow(
+      errorMessages.configType
+    );
+    expect(callConfigWithNonObjectFirstArgument((x) => x + 1)).toThrow(
+      errorMessages.configType
+    );
   });
 
   // test 4 - check if `config` warns about deprecation when there is a `urls`
@@ -52,7 +58,7 @@ describe('.config', () => {
 });
 
 // 2) `.init`
-// `init` is a function without parameters
+// `init` is a function with one parameter (optional)
 // it handle the initialization process of monaco-editor
 // returns an instance of monaco (with a cancelable promise)
 
@@ -60,6 +66,14 @@ describe('.init', () => {
   // test 1 - check if `init` is a function
   test('should be a function', () => {
     expect(loader.init).toBeInstanceOf(Function);
+  });
+
+  test('should return monaco instance', (done) => {
+    // load from inline object
+    loader.init({ monaco: { editor: {} } }).then((result) => {
+      expect(result).toHaveProperty('editor');
+      done();
+    });
   });
 });
 
@@ -76,7 +90,29 @@ describe('.__getMonacoInstance', () => {
 
   // test 2 - check if `__getMonacoInstance` returns `null`
   // as the initialization (.init) wasn't triggered
-  test('should return null', () => {
-    expect(loader.__getMonacoInstance()).toBe(null);
+  test('should return monaco instance', (done) => {
+    loader.init({ monaco: { editor: {} } }).then(() => {
+      expect(loader.__getMonacoInstance()).toHaveProperty('editor');
+      done();
+    });
+  });
+});
+
+// 4) `.dispose`
+// `dispose` is a function without parameters
+// it will set loader's internal state to default values
+describe('.dispose', () => {
+  // test 1 - check if `init` is a function
+  test('should be a function', () => {
+    expect(loader.dispose).toBeInstanceOf(Function);
+  });
+
+  test('should dispose', (done) => {
+    loader.init({ monaco: { editor: {} } }).then((result) => {
+      expect(result).toHaveProperty('editor');
+      loader.dispose();
+      expect(loader.__getMonacoInstance()).toBe(null);
+      done();
+    });
   });
 });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -7,7 +7,8 @@ interface CancelablePromise<T> extends Promise<T> {
 }
 
 declare namespace loader {
-  function init(): CancelablePromise<Monaco>;
+  function init(options?: { monaco?: Monaco }): CancelablePromise<Monaco>;
+  function dispose(): void;
   function config(params: {
     paths?: {
       vs?: string,


### PR DESCRIPTION
The community keeps asking how to load monaco from node_modules, here's the solution. Now you can inject the monaco instance to loader by giving an option to `init`.
```javascript
import * as  monaco from 'monaco-editor'
loader.init({ monaco }).then(result => {
  console.log(monaco === result)
})
```
The first `init` will call out a promise, every `init` call behind will return that promise.

you can reload also
```javascript
import * as  monaco from 'monaco-editor'
loader.init({ monaco }).then(result => {
  console.log(monaco === result) // true
})

// somewhere in code
loader.dispose()
loader.init().then((result) => {
  console.log(result) // monaco from default cdn
})
``` 
#14
suren-atoyan/monaco-react#327
suren-atoyan/monaco-react#322