### PR TITLE
upgrade monaco-editor version to 0.43.0

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -11,6 +11,6 @@
     "vite": "^2.8.0"
   },
   "dependencies": {
-    "monaco-editor": "^0.38.0"
+    "monaco-editor": "^0.43.0"
   }
 }

--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -152,10 +152,10 @@ is-core-module@^2.8.1:
   dependencies:
     has "^1.0.3"
 
-monaco-editor@^0.38.0:
-  version "0.38.0"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.38.0.tgz#7b3cd16f89b1b8867fcd3c96e67fccee791ff05c"
-  integrity sha512-11Fkh6yzEmwx7O0YoLxeae0qEGFwmyPRlVxpg7oF9czOOCB/iCjdJrG5I67da5WiXK3YJCxoz9TJFE8Tfq/v9A==
+monaco-editor@^0.43.0:
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.43.0.tgz#cb02a8d23d1249ad00b7cffe8bbecc2ac09d4baf"
+  integrity sha512-cnoqwQi/9fml2Szamv1XbSJieGJ1Dc8tENVMD26Kcfl7xGQWp7OBKMjlwKVGYFJ3/AXJjSOGvcqK7Ry/j9BM1Q==
 
 nanoid@^3.3.1:
   version "3.3.1"

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,6 +1,6 @@
 const config = {
   paths: {
-    vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.38.0/min/vs',
+    vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs',
   },
 }
 


### PR DESCRIPTION
To use the latest published version of monaco-editor. 👍 

Once merged, could you do a new release? 🙏

So we can then upgrade `@monaco-editor/react` dependencies to this version 👆 and enjoy TypeScript v5 with it. 😄