### PR TITLE
Update monaco-editor version to 0.46.0

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -11,6 +11,6 @@
     "vite": "^2.8.0"
   },
   "dependencies": {
-    "monaco-editor": "^0.43.0"
+    "monaco-editor": "^0.46.0"
   }
 }

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,6 +1,6 @@
 const config = {
   paths: {
-    vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs',
+    vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.46.0/min/vs',
   },
 }
 


### PR DESCRIPTION
Version `0.46.0` of `monaco-editor` introduced some **breaking changes**.

<img width="330" alt="43" src="https://github.com/suren-atoyan/monaco-loader/assets/60527897/e9487e13-b3ee-4651-ab71-fe5a1cfaf3f0">
<img width="300" alt="46" src="https://github.com/suren-atoyan/monaco-loader/assets/60527897/1cb69090-b3de-4108-a96f-9d37be753e24">

.

Namely, the `EditorOption` map has changed (source code [here](https://github.com/microsoft/vscode/blob/31c37ee8f63491495ac49e43b8544550fbae4533/src/vs/monaco.d.ts), API reference [here](https://microsoft.github.io/monaco-editor/docs.html#enums/editor.EditorOption.html#lineHeight)), breaking features such as this:
```tsx
import * as monaco from "monaco-editor";

// Value of `lineHeight` is incorrect: broken due to monaco-editor update
const lineHeight = editorRef.current.getOption(monaco.editor.EditorOption.lineHeight);

/*
* Note:
* `editorRef.current.getOption` refers to the `@monaco-editor/react -> Editor` instance
* `monaco.editor.[...]` refers to the `import *` from `monaco-editor`
* /
```

**API References**
- `.getOption()`: [here](https://microsoft.github.io/monaco-editor/docs.html#interfaces/editor.IStandaloneCodeEditor.html%23getOption)
- `EditorOption`: [here](https://microsoft.github.io/monaco-editor/docs.html#enums/editor.EditorOption.html)
- Source code for `EditorOption` can be found either on the monaco-editor [npm page](https://www.npmjs.com/package/monaco-editor?activeTab=code) as `esm/vs/editor/editor.api.d.ts` or the vscode [GitHub repo](https://github.com/microsoft/vscode/blob/31c37ee8f63491495ac49e43b8544550fbae4533/src/vs/monaco.d.ts) as `src/vs/monaco.d.ts`.

Because `editorRef.current.getOption()` comes from [monaco-react](https://github.com/suren-atoyan/monaco-react) (maintained by @suren-atoyan), but `monaco.editor.EditorOption.lineHeight` comes from [monaco-editor](https://github.com/microsoft/monaco-editor) (maintained by @microsoft), and the versions are out-of-sync, these changes break user applications that depends on [monaco-react](https://github.com/suren-atoyan/monaco-react).

I have personally ran into such issues, as have others. This is made apparent by issues created on the [monaco-react](https://github.com/suren-atoyan/monaco-react) repo such as this one: [Bug issue #546](https://github.com/suren-atoyan/monaco-react/issues/546).

Some temporary solutions before the PR merge is to modify the [Editor](https://github.com/suren-atoyan/monaco-react/blob/master/src/Editor/Editor.tsx) component in monaco-react to include these lines in the `useMount()` hook:
```ts
loader.config({ paths: { vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.46.0/min/vs' } }); // this is new
const cancelable = loader.init(); // this should already exist
```

Alternatively, one could also use the monaco instance provided by the monaco-react library by following [this guide](https://www.npmjs.com/package/@monaco-editor/react#monaco-instance) on the documentation. However, this is not ideal in some cases, because users still have to import from the `monaco-editor` package for TypeScript type definitions.

> NOTE: For TypeScript type definitions, this package uses the [monaco-editor](https://www.npmjs.com/package/monaco-editor) package as a peer dependency. So, if you need types and don't already have the [monaco-editor](https://www.npmjs.com/package/monaco-editor) package installed, you will need to do so

^ From the [documentation](https://www.npmjs.com/package/@monaco-editor/react)

Note: Similar PRs have been merged in the past (see #33), this is just the continuation of such efforts.